### PR TITLE
fix(online): 52dazi 协议对齐、深模块上传与会话生命周期闭环

### DIFF
--- a/.gbc/dazitui-core/src/online/gbc.client.rs.json
+++ b/.gbc/dazitui-core/src/online/gbc.client.rs.json
@@ -32,6 +32,28 @@
                 "dazitui/src/main.rs"
             ],
             "disabled": false
+        },
+        "ApiClient::session.persists_cookie_after_restart": {
+            "desc": "重启后从持久化存储恢复并回传PHPSESSID会话Cookie（满足US4）",
+            "test": "online::client::tests::saved_session_cookie_persists_and_replays_after_restart",
+            "executor": "cargo-dazitui",
+            "timeout_override": -1,
+            "heavy": 0,
+            "dependents": [
+                "dazitui/src/main.rs"
+            ],
+            "disabled": false
+        },
+        "ApiClient::upload_session.auto_retries_and_returns_outcome": {
+            "desc": "一站式跟打成绩上传：自动构建载荷、失效自动重登并返回结构化分享文本",
+            "test": "online::client::tests::upload_session_auto_retries_and_returns_outcome",
+            "executor": "cargo-dazitui",
+            "timeout_override": -1,
+            "heavy": 0,
+            "dependents": [
+                "dazitui/src/main.rs"
+            ],
+            "disabled": false
         }
     },
     "depends_on": [

--- a/.gbc/dazitui-core/src/online/gbc.token.rs.json
+++ b/.gbc/dazitui-core/src/online/gbc.token.rs.json
@@ -21,6 +21,15 @@
                 "dazitui/src/main.rs"
             ],
             "disabled": false
+        },
+        "AuthSession::save_and_load.roundtrip_with_cookie": {
+            "desc": "完整会话结构（Token与Cookie）持久化与读取一致",
+            "test": "online::token::tests::save_session_and_load_session_roundtrip_with_cookie",
+            "executor": "cargo-dazitui",
+            "timeout_override": -1,
+            "heavy": 0,
+            "dependents": [],
+            "disabled": false
         }
     },
     "depends_on": []

--- a/.gbc/dazitui/src/gbc.main.rs.json
+++ b/.gbc/dazitui/src/gbc.main.rs.json
@@ -88,7 +88,9 @@
             "guarantees": [
                 "ApiClient::login.parses_token",
                 "ApiClient::get_content.parses_fields",
-                "ApiClient::upload_result.parses_rank"
+                "ApiClient::upload_result.parses_rank",
+                "ApiClient::session.persists_cookie_after_restart",
+                "ApiClient::upload_session.auto_retries_and_returns_outcome"
             ]
         },
         {
@@ -128,6 +130,10 @@
         },
         {
             "symbol": "dazitui-core/src/online/share.rs:to_upload_stats",
+            "guarantees": []
+        },
+        {
+            "symbol": "dazitui-core/src/lib.rs:UploadOutcome",
             "guarantees": []
         }
     ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,7 +448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -470,6 +480,12 @@ dependencies = [
  "thiserror 1.0.69",
  "winapi",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "finl_unicode"
@@ -536,6 +552,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -920,7 +947,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1402,6 +1429,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,7 +1461,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1500,6 +1576,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -1590,6 +1672,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,7 +1731,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1833,6 +1921,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "ureq"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,9 +1937,12 @@ dependencies = [
  "encoding_rs",
  "log",
  "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
  "ureq-proto",
  "url",
  "utf8-zero",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1978,6 +2075,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,12 +2185,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -2161,6 +2340,12 @@ dependencies = [
  "syn 2.0.119",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/dazitui-core/Cargo.toml
+++ b/dazitui-core/Cargo.toml
@@ -10,7 +10,7 @@ cbc = { version = "0.1", features = ["alloc"], optional = true }
 rand = "0.9"
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
-ureq = { version = "3", default-features = false, features = ["charset", "cookies"], optional = true }
+ureq = { version = "3", default-features = false, features = ["charset", "cookies", "rustls"], optional = true }
 
 [features]
 default = []

--- a/dazitui-core/src/lib.rs
+++ b/dazitui-core/src/lib.rs
@@ -14,7 +14,9 @@ pub use settings::{
 #[cfg(feature = "online")]
 pub use online::auth::{env_credentials, is_auth_failure, should_auto_relogin};
 #[cfg(feature = "online")]
-pub use online::client::{ApiClient, ApiError, CompetitionText, LoginResult, RankResult};
+pub use online::client::{
+    ApiClient, ApiError, CompetitionText, LoginResult, RankResult, UploadOutcome,
+};
 #[cfg(feature = "online")]
 pub use online::protocol::{ProtocolError, build_request, decrypt, encrypt, parse_json};
 #[cfg(feature = "online")]
@@ -23,7 +25,7 @@ pub use online::share::{
     to_upload_stats,
 };
 #[cfg(feature = "online")]
-pub use online::token::TokenStore;
+pub use online::token::{AuthSession, TokenStore};
 
 /// 赛文：练习/比赛用的文字内容，来自本地文件或 52dazi.cn。
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/dazitui-core/src/online/client.rs
+++ b/dazitui-core/src/online/client.rs
@@ -354,6 +354,23 @@ impl ApiClient {
         ))
     }
 
+    /// 校验 token 是否有效（通过 getBaseInfo 的 isLogin 字段探测）。
+    pub fn validate_token(&self, token: &str) -> Result<bool, ApiError> {
+        let body = encrypt_value(&Value::Object(base_fields(Some(token))));
+        let resp = self.post("Api/System/getBaseInfo", &body)?;
+        let obj: Map<String, Value> = parse_api_response(&resp)?;
+        let is_login = obj.get("isLogin").and_then(Value::as_i64).unwrap_or(0);
+        Ok(is_login == 1)
+    }
+
+    /// 校验当前会话是否处于有效登录态。
+    pub fn validate_current_session(&self) -> Result<bool, ApiError> {
+        let Some(token) = self.current_token() else {
+            return Ok(false);
+        };
+        self.validate_token(&token)
+    }
+
     /// 上传成绩（`payload` 为业务字段，公共字段与 token 自动合并）。
     pub fn upload_result(&self, token: &str, payload: &Value) -> Result<RankResult, ApiError> {
         let body = upload_payload(token, payload);
@@ -1154,6 +1171,46 @@ mod tests {
         assert!(!text.content.is_empty(), "极速杯内容不应为空");
         assert_eq!(text.title, "市井人间烟火的生活本真");
     }
+
+    #[test]
+    #[ignore = "requires live 52dazi network access"]
+    fn real_gateway_upload_test() {
+        let client = ApiClient::new();
+        println!("Current token: {:?}", client.current_token());
+        let text = client.get_content(CompetitionType::Jisu).expect("get_content failed");
+        let stats = Stats {
+            wpm: 60.0,
+            typed_chars: text.content.chars().count(),
+            correct_chars: text.content.chars().count(),
+            wrong_chars: 0,
+            edits: 0,
+            wrong_total: 0,
+            key_frequency: vec![("a".into(), 100)],
+            edit_details: Vec::new(),
+        };
+        let upload_stats = crate::online::share::to_upload_stats(&stats, Duration::from_secs(60));
+        let payload = crate::online::share::build_upload_payload(&Text {
+            title: text.title.clone(),
+            content: text.content.clone(),
+            source: crate::TextSource::Online { competition_type: CompetitionType::Jisu },
+            word_boundaries: None,
+            shuffled: false,
+        }, &stats, &upload_stats, Duration::from_secs(60));
+        println!("Generated payload: {}", serde_json::to_string_pretty(&payload).unwrap());
+
+        if let Some(token) = client.current_token() {
+            let base_info_body = encrypt_value(&Value::Object(base_fields(Some(&token))));
+            let base_info_resp = client.post("Api/System/getBaseInfo", &base_info_body);
+            println!("getBaseInfo with token response: {base_info_resp:?}");
+            let res = client.upload_result(&token, &payload);
+            println!("Upload result with current token: {res:?}");
+        }
+
+        let bogus_res = client.upload_result("bogus_123", &payload);
+        println!("Upload result with bogus token: {bogus_res:?}");
+    }
 }
+
+
 
 

--- a/dazitui-core/src/online/client.rs
+++ b/dazitui-core/src/online/client.rs
@@ -3,6 +3,7 @@
 //! 响应解析与请求构造为纯函数（可独立测试），HTTP 调用是薄壳。
 //! 协议细节见 ADR-0002：请求体 AES 加密，响应为明文 JSON `{"error":0,"msg":…}`。
 
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use serde::Deserialize;
@@ -10,10 +11,11 @@ use serde::de::DeserializeOwned;
 use serde_json::{Map, Value, json};
 
 use super::protocol::encrypt_value;
-use crate::CompetitionType;
+use super::token::{AuthSession, TokenStore};
+use crate::{CompetitionType, Stats, Text};
 
 /// 52dazi 网关根地址。
-pub const BASE_URL: &str = "http://www.jsxiaoshi.com/index.php";
+pub const BASE_URL: &str = "https://www.jsxiaoshi.com/index.php";
 
 /// 请求体公共字段（前端固定携带）。
 const VERSION: &str = "v2.1.6";
@@ -40,13 +42,13 @@ pub struct LoginResult {
 /// 比赛赛文（getContent 响应 `msg` 对象）。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompetitionText {
-    /// 赛文内容（`msg["0"]`）。
+    /// 赛文内容（`msg["a_content"]` 或 `msg["0"]`）。
     pub content: String,
-    /// 赛文标题（`msg["7"]`，极速杯等类型可能缺失）。
+    /// 赛文标题（`msg["a_name"]` 或 `msg["7"]`）。
     pub title: String,
-    /// 作者（`msg["1"]`）。
+    /// 作者（`msg["a_author"]` 或 `msg["1"]`）。
     pub author: String,
-    /// 字数（`msg["6"]`）。
+    /// 字数（`msg["6"]` 或字符数）。
     pub word_num: usize,
 }
 
@@ -57,6 +59,17 @@ pub struct RankResult {
     pub message: String,
     /// 结构化排名（仅当服务器返回对象形式的 `msg` 时有值）。
     pub ranking: Option<String>,
+}
+
+/// 上传成绩高层结果（包含排名、提示文本与格式化分享文本）。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UploadOutcome {
+    /// 结构化排名（若有）。
+    pub ranking: Option<String>,
+    /// 格式化分享文本。
+    pub share_text: String,
+    /// 服务器返回的提示文本。
+    pub message: String,
 }
 
 /// 统一响应外壳：成功 `error == 0` 且 `msg` 为数据，失败 `msg` 为错误文本。
@@ -87,22 +100,24 @@ pub fn parse_login_response(body: &str) -> Result<LoginResult, ApiError> {
     Ok(LoginResult { token: m.token })
 }
 
-/// 解析载文响应：`msg` 为对象，字段 `"0"`=内容、`"1"`=作者、`"6"`=字数、`"7"`=标题。
-/// 除内容外其余字段可能缺失（极速杯只返回 `"0"`），缺失时用空串/0 兜底。
+/// 解析载文响应：优先读取真实文章字段 `a_name`/`a_content`，兼容数字键 `"0"`/`"7"`。
 pub fn parse_content_response(body: &str) -> Result<CompetitionText, ApiError> {
     let obj: Map<String, Value> = parse_api_response(body)?;
     let content = obj
-        .get("0")
+        .get("a_content")
+        .or_else(|| obj.get("0"))
         .and_then(Value::as_str)
         .unwrap_or("")
         .to_string();
     let title = obj
-        .get("7")
+        .get("a_name")
+        .or_else(|| obj.get("7"))
         .and_then(Value::as_str)
         .unwrap_or("")
         .to_string();
     let author = obj
-        .get("1")
+        .get("a_author")
+        .or_else(|| obj.get("1"))
         .and_then(Value::as_str)
         .unwrap_or("")
         .to_string();
@@ -113,7 +128,7 @@ pub fn parse_content_response(body: &str) -> Result<CompetitionText, ApiError> {
                 .map(|n| n as usize)
                 .or_else(|| v.as_str().and_then(|s| s.parse::<usize>().ok()))
         })
-        .unwrap_or(0);
+        .unwrap_or_else(|| content.chars().count());
     Ok(CompetitionText {
         content,
         title,
@@ -122,7 +137,7 @@ pub fn parse_content_response(body: &str) -> Result<CompetitionText, ApiError> {
     })
 }
 
-/// 标题为空时用比赛类型名兜底（极速杯不返回标题字段，验收要求「标题显示比赛类型」）。
+/// 标题为空时用比赛类型名兜底（验收要求「无标题时显示比赛类型」）。
 fn with_title_fallback(
     mut text: CompetitionText,
     competition_type: CompetitionType,
@@ -163,9 +178,15 @@ pub fn parse_upload_response(body: &str) -> Result<RankResult, ApiError> {
     }
 }
 
-/// 请求体公共字段：`version` + `subversions` + 可选 `token`。
+/// 请求体公共字段：`from` + `timestamp` + `version` + `subversions` + 可选 `token`。
 fn base_fields(token: Option<&str>) -> Map<String, Value> {
     let mut m = Map::new();
+    m.insert("from".into(), json!("web"));
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    m.insert("timestamp".into(), json!(timestamp));
     m.insert("version".into(), json!(VERSION));
     m.insert("subversions".into(), json!(SUBVERSIONS));
     if let Some(t) = token {
@@ -201,11 +222,14 @@ fn upload_payload(token: &str, payload: &Value) -> String {
     encrypt_value(&Value::Object(m))
 }
 
-/// 52dazi 客户端。
+
+/// 52dazi 客户端（深模块：封装会话持久化、Cookie 回传、自动重登与上传全流程）。
 #[derive(Debug, Clone)]
 pub struct ApiClient {
     agent: ureq::Agent,
     base_url: String,
+    session: Arc<Mutex<Option<AuthSession>>>,
+    token_store: Option<TokenStore>,
 }
 
 impl Default for ApiClient {
@@ -215,35 +239,109 @@ impl Default for ApiClient {
 }
 
 impl ApiClient {
-    /// 指向 52dazi 网关的客户端（10 秒超时）。
+    /// 指向 52dazi 网关的客户端（自动从默认路径加载与保存会话，10 秒超时）。
     ///
     /// 网关地址可用 `DAZITUI_BASE_URL` 环境变量覆盖（调试/抓包用，如反向代理）。
     pub fn new() -> Self {
+        let store = TokenStore::with_default_path();
         let base_url = std::env::var("DAZITUI_BASE_URL").unwrap_or_else(|_| BASE_URL.to_string());
-        Self::with_base_url(&base_url)
+        Self::with_base_url_and_store(&base_url, Some(store))
     }
 
-    /// 指定网关根地址（测试时指向本地 mock）。
+    /// 指定网关根地址（测试时指向本地 mock，不持久化到默认文件）。
     pub fn with_base_url(base_url: &str) -> Self {
+        Self::with_base_url_and_store(base_url, None)
+    }
+
+    /// 指定会话存储（使用默认网关地址）。
+    pub fn with_store(token_store: TokenStore) -> Self {
+        let base_url = std::env::var("DAZITUI_BASE_URL").unwrap_or_else(|_| BASE_URL.to_string());
+        Self::with_base_url_and_store(&base_url, Some(token_store))
+    }
+
+    /// 指定网关根地址与会话存储。
+    pub fn with_base_url_and_store(base_url: &str, token_store: Option<TokenStore>) -> Self {
         let agent = ureq::Agent::config_builder()
             .timeout_global(Some(Duration::from_secs(10)))
             .build()
             .new_agent();
+        let initial_session = token_store.as_ref().and_then(|s| s.load_session());
         Self {
             agent,
             base_url: base_url.to_string(),
+            session: Arc::new(Mutex::new(initial_session)),
+            token_store,
         }
     }
 
-    /// 登录：返回 token。
+    /// 当前是否处于已登录状态（持有有效 token）。
+    pub fn is_logged_in(&self) -> bool {
+        self.current_token().is_some()
+    }
+
+    /// 获取当前登录 token。
+    pub fn current_token(&self) -> Option<String> {
+        self.session
+            .lock()
+            .ok()
+            .and_then(|s| s.as_ref().and_then(|x| {
+                if x.token.is_empty() {
+                    None
+                } else {
+                    Some(x.token.clone())
+                }
+            }))
+    }
+
+    /// 获取当前完整会话（token + cookie）。
+    pub fn current_session(&self) -> Option<AuthSession> {
+        self.session.lock().ok().and_then(|s| s.clone())
+    }
+
+    /// 设置并同步持久化会话。
+    pub fn set_session(&self, session: Option<AuthSession>) {
+        if let Ok(mut lock) = self.session.lock() {
+            *lock = session.clone();
+        }
+        if let Some(ref store) = self.token_store {
+            if let Some(ref sess) = session {
+                let _ = store.save_session(sess);
+            } else {
+                let _ = store.clear();
+            }
+        }
+    }
+
+    /// 注销登录：清空内存与磁盘会话。
+    pub fn logout(&self) {
+        self.set_session(None);
+    }
+
+    /// 登录：调用网关，提取 token 与 session cookie 并自动持久化。
     pub fn login(&self, username: &str, password: &str) -> Result<LoginResult, ApiError> {
         let body = login_payload(username, password);
         let resp = self.post("Api/User/login", &body)?;
-        parse_login_response(&resp)
+        let result = parse_login_response(&resp)?;
+        let existing_cookie = self
+            .session
+            .lock()
+            .ok()
+            .and_then(|s| s.as_ref().and_then(|x| x.cookie.clone()));
+        let session = AuthSession::new(&result.token, existing_cookie);
+        self.set_session(Some(session));
+        Ok(result)
     }
 
-    /// 按比赛类型载入赛文（需登录）。
-    pub fn get_content(
+    /// 按比赛类型载入赛文（自动使用当前登录 token）。
+    pub fn get_content(&self, competition_type: CompetitionType) -> Result<CompetitionText, ApiError> {
+        let token = self
+            .current_token()
+            .ok_or_else(|| ApiError::Server("请先登录 52dazi".into()))?;
+        self.get_content_with_token(&token, competition_type)
+    }
+
+    /// 按比赛类型与指定 token 载入赛文。
+    pub fn get_content_with_token(
         &self,
         token: &str,
         competition_type: CompetitionType,
@@ -263,25 +361,107 @@ impl ApiClient {
         parse_upload_response(&resp)
     }
 
-    /// 发送加密请求体，返回响应文本。
+    /// 一站式完成跟打成绩上传（深模块核心接口）：
+    /// 自动校验登录态、计算指标、构造 payload、上传结果；
+    /// 若 token 失效且配置了环境变量凭据则自动重登重试一次；
+    /// 成功后自动格式化分享文本并返回 `UploadOutcome`。
+    pub fn upload_session(
+        &self,
+        text: &Text,
+        stats: &Stats,
+        elapsed: Duration,
+    ) -> Result<UploadOutcome, ApiError> {
+        let token = self
+            .current_token()
+            .ok_or_else(|| ApiError::Server("未登录，无法上传成绩".into()))?;
+        let upload_stats = super::share::to_upload_stats(stats, elapsed);
+        let payload = super::share::build_upload_payload(text, stats, &upload_stats, elapsed);
+        let rank_res = match self.upload_result(&token, &payload) {
+            Ok(r) => Ok(r),
+            Err(e) => {
+                if super::auth::is_auth_failure(&e) {
+                    if let Some((user, pass)) =
+                        super::auth::env_credentials(|k| std::env::var(k).ok())
+                    {
+                        if let Ok(new_login) = self.login(&user, &pass) {
+                            let new_payload = super::share::build_upload_payload(
+                                text,
+                                stats,
+                                &upload_stats,
+                                elapsed,
+                            );
+                            self.upload_result(&new_login.token, &new_payload)
+                        } else {
+                            Err(e)
+                        }
+                    } else {
+                        Err(e)
+                    }
+                } else {
+                    Err(e)
+                }
+            }
+        }?;
+        let ranking = rank_res.ranking.clone();
+        let rank_num = ranking.as_deref().and_then(|s| s.parse::<u32>().ok());
+        let share_text = super::share::format_share_text(&text.source, rank_num, &upload_stats);
+        Ok(UploadOutcome {
+            ranking,
+            share_text,
+            message: rank_res.message,
+        })
+    }
+
+    /// 发送加密请求体，维护 Session Cookie，返回响应文本。
     fn post(&self, path: &str, body: &str) -> Result<String, ApiError> {
         let url = format!("{}/{path}", self.base_url);
-        let mut resp = self
-            .agent
-            .post(&url)
-            .send(body)
-            .map_err(|e| ApiError::Transport(e.to_string()))?;
+        let mut req = self.agent.post(&url);
+        if let Some(cookie) = self
+            .session
+            .lock()
+            .ok()
+            .and_then(|s| s.as_ref().and_then(|x| x.cookie.clone()))
+        {
+            req = req.header("Cookie", &cookie);
+        }
+        let mut resp = req.send(body).map_err(|e| ApiError::Transport(e.to_string()))?;
+        let new_cookie = resp
+            .headers()
+            .get("set-cookie")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.split(';').next().unwrap_or(s).trim().to_string());
+        if let Some(cookie_val) = new_cookie {
+            if let Ok(mut lock) = self.session.lock() {
+                if let Some(sess) = lock.as_mut() {
+                    sess.cookie = Some(cookie_val);
+                    if let Some(ref store) = self.token_store {
+                        let _ = store.save_session(sess);
+                    }
+                } else {
+                    *lock = Some(AuthSession::new("", Some(cookie_val)));
+                }
+            }
+        }
         resp.body_mut()
             .read_to_string()
             .map_err(|e| ApiError::Transport(e.to_string()))
     }
 }
 
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // ---- 响应解析 ----
+    #[test]
+    fn check_ureq_header_api() {
+        let resp = ureq::http::Response::builder()
+            .header("Set-Cookie", "PHPSESSID=test12345; path=/")
+            .body(())
+            .unwrap();
+        let cookie_str = resp.headers().get("set-cookie").and_then(|v| v.to_str().ok());
+        assert_eq!(cookie_str, Some("PHPSESSID=test12345; path=/"));
+    }
 
     #[test]
     fn parse_login_returns_token() {
@@ -309,14 +489,24 @@ mod tests {
     }
 
     #[test]
+    fn parse_content_response_with_named_fields_extracts_title_and_content() {
+        // 52dazi 实测响应：a_name 与 a_content
+        let body = r#"{"error":0,"msg":{"a_name":"市井人间烟火的生活本真","a_content":"市井人间烟火，是最真实的生活本真","number":99999}}"#;
+        let r = parse_content_response(body).unwrap();
+        assert_eq!(r.title, "市井人间烟火的生活本真");
+        assert_eq!(r.content, "市井人间烟火，是最真实的生活本真");
+        assert_eq!(r.word_num, "市井人间烟火，是最真实的生活本真".chars().count());
+    }
+
+    #[test]
     fn parse_content_missing_optional_fields_does_not_panic() {
-        // 极速杯实测：只返回 "0"（内容），其余字段缺失。
+        // 兼容历史数字键格式：只返回 "0"（内容）
         let body = r#"{"error":0,"msg":{"0":"只有内容"}}"#;
         let r = parse_content_response(body).unwrap();
         assert_eq!(r.content, "只有内容");
         assert_eq!(r.title, "");
         assert_eq!(r.author, "");
-        assert_eq!(r.word_num, 0);
+        assert_eq!(r.word_num, "只有内容".chars().count());
     }
 
     #[test]
@@ -335,12 +525,12 @@ mod tests {
     fn with_title_fallback_keeps_server_title_when_present() {
         let text = CompetitionText {
             content: "x".into(),
-            title: "锦标赛第3279期".into(),
+            title: "市井人间烟火的生活本真".into(),
             author: "".into(),
             word_num: 0,
         };
-        let filled = with_title_fallback(text, CompetitionType::Jinbiao);
-        assert_eq!(filled.title, "锦标赛第3279期");
+        let filled = with_title_fallback(text, CompetitionType::Jisu);
+        assert_eq!(filled.title, "市井人间烟火的生活本真");
     }
 
     #[test]
@@ -380,6 +570,8 @@ mod tests {
         let v: Value = serde_json::from_str(&decrypted).unwrap();
         assert_eq!(v["username"], "alice");
         assert_eq!(v["password"], "s3cret");
+        assert_eq!(v["from"], "web");
+        assert!(v["timestamp"].is_number(), "应包含秒级时间戳");
         assert_eq!(v["version"], VERSION);
         assert_eq!(v["subversions"], SUBVERSIONS);
         assert!(v.get("token").is_none(), "登录请求不应带 token");
@@ -633,7 +825,7 @@ mod tests {
         assert_eq!(login.token, "t1");
         // 步骤 2：载入赛文——这是现行两步测试缺的关键一步
         let text = client
-            .get_content("t1", CompetitionType::Jisu)
+            .get_content_with_token("t1", CompetitionType::Jisu)
             .expect("getContent 应成功（cookie 应仍有效）");
         assert_eq!(text.content, "户外溯溪玩水的夏日治愈");
         // 步骤 3：上传成绩——真实 bug 现场：服务端在此步回「用户名不能为空！」
@@ -703,13 +895,15 @@ mod tests {
             let v: Value = serde_json::from_str(&plaintext)
                 .unwrap_or_else(|e| panic!("解密后不是有效 JSON: {e}\n明文: {plaintext}"));
             // 公共字段（由 upload_payload 合并）
+            assert_eq!(v["from"], "web");
+            assert!(v["timestamp"].is_number(), "应包含时间戳");
             assert_eq!(v["version"], VERSION);
             assert_eq!(v["subversions"], SUBVERSIONS);
             assert_eq!(v["token"], "tok-9");
             // 业务字段：前端 resultPostData 完整 schema（含新补的字段）
             for key in [
                 "textTitle", "speed", "keystrokes", "maChang", "wordNum", "typingTime",
-                "huiGai", "huiChe", "jianShu", "jianZhun", "repeatNum", "daCi",
+                "huiGai", "huiChe", "jianShu", "jianZhun", "accuracy", "repeatNum", "daCi",
                 "wrongNum", "inputMethod", "backspace", "xuanChong", "keyMethod",
                 "challengeFlag", "isFirstSubmit", "isGroupText",
             ] {
@@ -743,6 +937,7 @@ mod tests {
             "huiChe": 0,
             "jianShu": 1024,
             "jianZhun": "100.00%",
+            "accuracy": 100.0,
             "repeatNum": 0,
             "daCi": "0%",
             "wrongNum": 0,
@@ -751,7 +946,7 @@ mod tests {
             "xuanChong": 0,
             "keyMethod": "0%",
             "challengeFlag": 0,
-            "isFirstSubmit": 0,
+            "isFirstSubmit": 1,
             "isGroupText": 0,
         });
         let rank = client
@@ -761,4 +956,184 @@ mod tests {
 
         server.join().unwrap();
     }
+
+    #[test]
+    fn saved_session_cookie_persists_and_replays_after_restart() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        fn temp_path(suffix: &str) -> std::path::PathBuf {
+            let stamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            std::env::temp_dir().join(format!("dazitui-client-test-{stamp}-{suffix}"))
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let store_path = temp_path("session-cookie-restart");
+        let store = TokenStore::new(store_path.clone());
+
+        let server = std::thread::spawn(move || {
+            // 请求 1：login
+            let (mut conn1, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = conn1.read(&mut buf).unwrap();
+            let body1 = r#"{"error":0,"msg":{"token":"tok-live"}}"#;
+            conn1.write_all(
+                format!(
+                    "HTTP/1.1 200 OK\r\nSet-Cookie: PHPSESSID=session_persisted_999; path=/\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body1}",
+                    body1.len()
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+            drop(conn1);
+
+            // 请求 2：由新的 ApiClient 实例发起（模拟重启），必须回传 PHPSESSID=session_persisted_999
+            let (mut conn2, _) = listener.accept().unwrap();
+            let mut total2 = Vec::new();
+            loop {
+                let n = conn2.read(&mut buf).unwrap();
+                if n == 0 {
+                    break;
+                }
+                total2.extend_from_slice(&buf[..n]);
+                if total2.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let req2 = String::from_utf8_lossy(&total2);
+            assert!(
+                req2.contains("PHPSESSID=session_persisted_999"),
+                "重启后的新 ApiClient 未能回传已持久化的 PHPSESSID cookie！请求为:\n{req2}"
+            );
+            let body2 = r#"{"error":0,"msg":"上传成功"}"#;
+            conn2.write_all(
+                format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body2}",
+                    body2.len()
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+        });
+
+        // 第一次运行：登录并保存
+        let client1 = ApiClient::with_base_url_and_store(&format!("http://{addr}"), Some(store.clone()));
+        let login_res = client1.login("alice", "pass").unwrap();
+        assert_eq!(login_res.token, "tok-live");
+        assert!(client1.is_logged_in());
+
+        // 模拟进程重启：创建全新 ApiClient 实例，仅挂载同一 store
+        let client2 = ApiClient::with_base_url_and_store(&format!("http://{addr}"), Some(store));
+        assert!(client2.is_logged_in(), "新实例应自动加载会话并判定为已登录");
+        assert_eq!(client2.current_token().as_deref(), Some("tok-live"));
+
+        // 发起上传，验证 cookie 成功回传
+        let rank = client2
+            .upload_result("tok-live", &json!({"speed": 60.0}))
+            .expect("使用持久化会话上传应成功");
+        assert_eq!(rank.message, "上传成功");
+
+        server.join().unwrap();
+        let _ = std::fs::remove_file(store_path);
+    }
+
+    #[test]
+    fn upload_session_auto_retries_and_returns_outcome() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use crate::TextSource;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = std::thread::spawn(move || {
+            // 请求 1：首次 uploadResult，返回 token 过期错误
+            let (mut conn1, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = conn1.read(&mut buf).unwrap();
+            let body1 = r#"{"error":1,"msg":"登录已过期，请重新登录"}"#;
+            conn1.write_all(
+                format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body1}",
+                    body1.len()
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+            drop(conn1);
+
+            // 请求 2：自动重登 login
+            let (mut conn2, _) = listener.accept().unwrap();
+            let _ = conn2.read(&mut buf).unwrap();
+            let body2 = r#"{"error":0,"msg":{"token":"tok-new-auto"}}"#;
+            conn2.write_all(
+                format!(
+                    "HTTP/1.1 200 OK\r\nSet-Cookie: PHPSESSID=new_cookie_auto; path=/\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body2}",
+                    body2.len()
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+            drop(conn2);
+
+            // 请求 3：重试 uploadResult，成功并返回排名
+            let (mut conn3, _) = listener.accept().unwrap();
+            let _ = conn3.read(&mut buf).unwrap();
+            let body3 = r#"{"error":0,"msg":{"ranking":3,"rankTips":"第3名"}}"#;
+            conn3.write_all(
+                format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body3}",
+                    body3.len()
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+        });
+
+        unsafe {
+            std::env::set_var("DAZITUI_USER", "test_user");
+            std::env::set_var("DAZITUI_PASS", "test_pass");
+        }
+
+        let client = ApiClient::with_base_url(&format!("http://{addr}"));
+        client.set_session(Some(AuthSession::from_token("tok-old-expired")));
+
+        let text = Text {
+            title: "极速杯第100期".into(),
+            content: "打字练习测试".into(),
+            source: TextSource::Online { competition_type: CompetitionType::Jisu },
+            word_boundaries: None,
+            shuffled: false,
+        };
+        let stats = Stats {
+            wpm: 92.5,
+            typed_chars: 6,
+            correct_chars: 6,
+            wrong_chars: 0,
+            edits: 0,
+            wrong_total: 0,
+            key_frequency: vec![("a".into(), 10)],
+            edit_details: Vec::new(),
+        };
+
+        let outcome = client.upload_session(&text, &stats, Duration::from_secs(10)).unwrap();
+        assert_eq!(outcome.ranking.as_deref(), Some("3"));
+        assert!(outcome.share_text.contains("第3名"));
+        assert!(outcome.share_text.contains("WPM 92.5"));
+        assert_eq!(client.current_token().as_deref(), Some("tok-new-auto"));
+
+        unsafe {
+            std::env::remove_var("DAZITUI_USER");
+            std::env::remove_var("DAZITUI_PASS");
+        }
+
+        server.join().unwrap();
+    }
 }
+
+

--- a/dazitui-core/src/online/client.rs
+++ b/dazitui-core/src/online/client.rs
@@ -1134,6 +1134,26 @@ mod tests {
 
         server.join().unwrap();
     }
+
+    #[test]
+    #[ignore = "requires live 52dazi network access"]
+    fn real_gateway_connection() {
+        let client = ApiClient::new();
+        let res = client.login("invalid_user_test", "invalid_pass_test");
+        assert!(matches!(res, Err(ApiError::Server(_))));
+    }
+
+    #[test]
+    #[ignore = "requires live 52dazi network access"]
+    fn real_gateway_get_content() {
+        let client = ApiClient::new();
+        // 极速杯公开载文
+        let res = client.get_content_with_token("", CompetitionType::Jisu);
+        assert!(res.is_ok(), "极速杯载文应当成功: {res:?}");
+        let text = res.unwrap();
+        assert!(!text.content.is_empty(), "极速杯内容不应为空");
+        assert_eq!(text.title, "市井人间烟火的生活本真");
+    }
 }
 
 

--- a/dazitui-core/src/online/share.rs
+++ b/dazitui-core/src/online/share.rs
@@ -103,6 +103,7 @@ pub fn build_upload_payload(
         "huiChe": 0,
         "jianShu": total_keys,
         "jianZhun": format!("{:.2}%", accuracy_pct),
+        "accuracy": accuracy_pct,
         "repeatNum": 0,
         "daCi": "0%",
         "wrongNum": stats.wrong_total,
@@ -111,7 +112,7 @@ pub fn build_upload_payload(
         "xuanChong": 0,
         "keyMethod": "0%",
         "challengeFlag": 0,
-        "isFirstSubmit": 0,
+        "isFirstSubmit": 1,
         "isGroupText": 0,
     })
 }
@@ -215,16 +216,16 @@ mod tests {
             key_length: 2.8,
         };
         let text = Text {
-            title: "锦标赛第3279期".into(),
+            title: "市井人间烟火的生活本真".into(),
             content: "你好世界".into(),
             source: TextSource::Online {
-                competition_type: CompetitionType::Jinbiao,
+                competition_type: CompetitionType::Jisu,
             },
             word_boundaries: None,
             shuffled: false,
         };
         let v = build_upload_payload(&text, &stats, &up, Duration::from_secs_f64(85.23));
-        assert_eq!(v["textTitle"], "锦标赛第3279期");
+        assert_eq!(v["textTitle"], "市井人间烟火的生活本真");
         assert_eq!(v["speed"], 85.2);
         assert_eq!(v["keystrokes"], 3.5);
         assert_eq!(v["maChang"], 2.8);
@@ -233,9 +234,12 @@ mod tests {
         assert_eq!(v["huiGai"], 1); // sample_stats edits=1
         assert_eq!(v["jianShu"], 140); // 100 + 40
         assert_eq!(v["wrongNum"], 3); // sample_stats wrong_total=3
+        assert_eq!(v["accuracy"], 100.0);
+        assert_eq!(v["jianZhun"], "100.00%");
         assert_eq!(v["challengeFlag"], 0);
-        assert_eq!(v["isFirstSubmit"], 0);
+        assert_eq!(v["isFirstSubmit"], 1);
     }
+
 
     #[test]
     fn build_upload_payload_includes_frontend_schema_fields() {

--- a/dazitui-core/src/online/token.rs
+++ b/dazitui-core/src/online/token.rs
@@ -1,9 +1,39 @@
-//! 52dazi.cn 登录 token 持久化（纯文件读写，零网络依赖）。
+//! 52dazi.cn 登录会话持久化（支持 Token + Session Cookie，纯文件读写，零网络依赖）。
 
 use std::io;
 use std::path::{Path, PathBuf};
 
-/// token 文件读写。文件不存在或为空视为未登录。
+use serde::{Deserialize, Serialize};
+
+/// 登录会话数据：包含接口 token 与可选的 HTTP 会话 cookie（PHPSESSID）。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthSession {
+    /// 接口认证 token。
+    pub token: String,
+    /// HTTP Cookie 头（如 "PHPSESSID=xxx"），用于维持服务端 PHP 会话。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cookie: Option<String>,
+}
+
+impl AuthSession {
+    /// 仅包含 token 的会话。
+    pub fn from_token(token: impl Into<String>) -> Self {
+        Self {
+            token: token.into(),
+            cookie: None,
+        }
+    }
+
+    /// 包含 token 与 cookie 的会话。
+    pub fn new(token: impl Into<String>, cookie: Option<String>) -> Self {
+        Self {
+            token: token.into(),
+            cookie,
+        }
+    }
+}
+
+/// 会话文件读写。文件不存在或为空视为未登录。
 #[derive(Debug, Clone)]
 pub struct TokenStore {
     path: PathBuf,
@@ -28,23 +58,50 @@ impl TokenStore {
         &self.path
     }
 
-    /// 保存 token（自动创建父目录）。
-    pub fn save(&self, token: &str) -> io::Result<()> {
+    /// 保存完整会话（JSON 格式，自动创建父目录）。
+    pub fn save_session(&self, session: &AuthSession) -> io::Result<()> {
         if let Some(parent) = self.path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        std::fs::write(&self.path, token)
+        let json_str = serde_json::to_string(session)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        std::fs::write(&self.path, json_str)
+    }
+
+    /// 读取完整会话：兼容 JSON 格式与历史纯 token 文本文件。
+    pub fn load_session(&self) -> Option<AuthSession> {
+        let s = std::fs::read_to_string(&self.path).ok()?;
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        // 尝试解析 JSON 会话格式
+        if let Ok(sess) = serde_json::from_str::<AuthSession>(trimmed) {
+            if !sess.token.is_empty() {
+                return Some(sess);
+            }
+        }
+        // 兼容旧格式：纯文本 token
+        Some(AuthSession::from_token(trimmed))
+    }
+
+    /// 保存 token（兼容旧接口：若已有 cookie 则保留）。
+    pub fn save(&self, token: &str) -> io::Result<()> {
+        let existing_cookie = self.load_session().and_then(|s| s.cookie);
+        self.save_session(&AuthSession::new(token, existing_cookie))
     }
 
     /// 读取 token；文件不存在或为空返回 `None`（未登录）。
     pub fn load(&self) -> Option<String> {
-        let s = std::fs::read_to_string(&self.path).ok()?;
-        let s = s.trim();
-        if s.is_empty() {
-            None
-        } else {
-            Some(s.to_string())
+        self.load_session().map(|s| s.token)
+    }
+
+    /// 清空持久化会话。
+    pub fn clear(&self) -> io::Result<()> {
+        if self.path.exists() {
+            std::fs::remove_file(&self.path)?;
         }
+        Ok(())
     }
 }
 
@@ -70,6 +127,25 @@ mod tests {
     }
 
     #[test]
+    fn save_session_and_load_session_roundtrip_with_cookie() {
+        let store = TokenStore::new(temp_path("session-roundtrip"));
+        let session = AuthSession::new("tok-999", Some("PHPSESSID=session_xyz".to_string()));
+        store.save_session(&session).unwrap();
+        assert_eq!(store.load_session(), Some(session));
+        let _ = std::fs::remove_file(store.path());
+    }
+
+    #[test]
+    fn load_session_parses_legacy_plain_text_token() {
+        let store = TokenStore::new(temp_path("legacy-plain"));
+        std::fs::write(store.path(), "legacy-plain-token-123\n").unwrap();
+        let loaded = store.load_session().unwrap();
+        assert_eq!(loaded.token, "legacy-plain-token-123");
+        assert_eq!(loaded.cookie, None);
+        let _ = std::fs::remove_file(store.path());
+    }
+
+    #[test]
     fn save_creates_parent_directories() {
         let dir = temp_path("nested-dir");
         let store = TokenStore::new(dir.join("sub").join("token"));
@@ -82,6 +158,7 @@ mod tests {
     fn missing_file_is_logged_out() {
         let store = TokenStore::new(temp_path("missing"));
         assert_eq!(store.load(), None);
+        assert_eq!(store.load_session(), None);
     }
 
     #[test]
@@ -89,6 +166,7 @@ mod tests {
         let store = TokenStore::new(temp_path("empty"));
         std::fs::write(store.path(), "").unwrap();
         assert_eq!(store.load(), None);
+        assert_eq!(store.load_session(), None);
         let _ = std::fs::remove_file(store.path());
     }
 
@@ -97,6 +175,8 @@ mod tests {
         let store = TokenStore::new(temp_path("blank"));
         std::fs::write(store.path(), "  \n\t").unwrap();
         assert_eq!(store.load(), None);
+        assert_eq!(store.load_session(), None);
         let _ = std::fs::remove_file(store.path());
     }
 }
+

--- a/dazitui/src/main.rs
+++ b/dazitui/src/main.rs
@@ -450,31 +450,8 @@ impl App {
         };
     }
 
-
-    /// 用环境变量凭据重新登录并重试上传一次；重登失败时保留失败状态并附原始错误。
-    fn retry_after_relogin(
-        &mut self,
-        credentials: (String, String),
-        stats: &Stats,
-        elapsed: Duration,
-    ) -> UploadState {
-        let (user, pass) = credentials;
-        match self.api.login(&user, &pass) {
-            Ok(r) => {
-                let _ = self.token_store.save(&r.token);
-                self.token = Some(r.token);
-                self.logged_in = true;
-                self.perform_upload(stats, elapsed)
-            }
-            Err(e) => UploadState::Failed {
-                message: "自动重登失败，请手动重新登录".to_string(),
-                need_relogin: true,
-                detail: Some(api_error_text(&e)),
-            },
-        }
-    }
-
     /// 执行上传：调用 API 客户端一站式上传成绩（包含指标计算、payload 构建、网关通信、自动重登与分享文本生成）。
+
     fn perform_upload(&self, stats: &Stats, elapsed: Duration) -> UploadState {
         if !self.logged_in && !self.api.is_logged_in() {
             return UploadState::Failed {
@@ -3156,65 +3133,8 @@ mod tests {
     }
 
     #[test]
-    fn retry_after_relogin_relogins_and_uploads() {
-        // 自动重登成功：token 更新为新值，并重试上传成功。
-        let (port, handle) = mock_server(&[
-            (
-                "/Api/User/login",
-                r#"{"error":0,"msg":{"token":"new-tok"}}"#,
-            ),
-            (
-                "/Api/Rank/uploadResult",
-                r#"{"error":0,"msg":{"ranking":5,"rankTips":"恭喜获得第5名"}}"#,
-            ),
-        ]);
-        let mut app = test_app(online_text("你好世界"));
-        app.token = Some("old-tok".into());
-        app.api = ApiClient::with_base_url(&format!("http://127.0.0.1:{port}"));
-        let stats = app.session.finish(Duration::from_secs(40));
-        let up = app.retry_after_relogin(
-            ("user".into(), "pass".into()),
-            &stats,
-            Duration::from_secs(40),
-        );
-        handle.join().unwrap();
-        assert_eq!(app.token.as_deref(), Some("new-tok"));
-        assert!(matches!(
-            &up,
-            UploadState::Success { ranking, .. } if ranking.as_deref() == Some("5")
-        ));
-    }
-
-    #[test]
-    fn retry_after_relogin_failed_login_keeps_failure() {
-        // 自动重登失败：保留失败状态、附重登原始错误，token 不变。
-        let (port, handle) = mock_server(&[(
-            "/Api/User/login",
-            r#"{"error":1,"msg":"您的用户名或密码错误！"}"#,
-        )]);
-        let mut app = test_app(online_text("你好世界"));
-        app.token = Some("old-tok".into());
-        app.api = ApiClient::with_base_url(&format!("http://127.0.0.1:{port}"));
-        let stats = app.session.finish(Duration::from_secs(10));
-        let up = app.retry_after_relogin(
-            ("user".into(), "pass".into()),
-            &stats,
-            Duration::from_secs(10),
-        );
-        handle.join().unwrap();
-        assert_eq!(app.token.as_deref(), Some("old-tok"));
-        assert_eq!(
-            up,
-            UploadState::Failed {
-                message: "自动重登失败，请手动重新登录".to_string(),
-                need_relogin: true,
-                detail: Some("您的用户名或密码错误！".to_string()),
-            }
-        );
-    }
-
-    #[test]
     fn submit_login_retries_pending_upload_in_finished_state() {
+
         let (port, handle) = mock_server(&[
             (
                 "/Api/User/login",

--- a/dazitui/src/main.rs
+++ b/dazitui/src/main.rs
@@ -158,7 +158,7 @@ impl App {
             Session::new_gated_with_words(&text.content, text.source.is_builtin(), &wb)
         };
         let settings = settings_store.load();
-        // 自动登录与会话恢复：若已有已持久化的会话则直接保持已登录；未登录时若有环境变量则尝试自动登录。
+        // 自动登录与会话恢复：若未登录且有环境变量则尝试自动登录。
         let login_notice =
             if !api.is_logged_in() && let Some((user, pass)) = env_credentials(|k| std::env::var(k).ok()) {
                 match api.login(&user, &pass) {
@@ -475,6 +475,10 @@ impl App {
             }
             Err(e) => {
                 let need_relogin = is_auth_failure(&e);
+                if need_relogin {
+                    self.api.logout();
+                    let _ = self.token_store.clear();
+                }
                 // 登录失效：主文案用友好提示，原始服务器错误降级为次要信息。
                 let (message, detail) = if need_relogin {
                     (
@@ -490,6 +494,7 @@ impl App {
                     detail,
                 }
             }
+
         }
     }
 }
@@ -861,11 +866,22 @@ fn themed_block(theme: Theme) -> Block<'static> {
 fn login_input(form: &mut LoginForm, key: KeyEvent) -> LoginAction {
     match key.code {
         KeyCode::Esc => LoginAction::Cancel,
-        KeyCode::Tab => {
+        KeyCode::Tab | KeyCode::Down => {
             form.focus = 1 - form.focus;
             LoginAction::None
         }
-        KeyCode::Enter => LoginAction::Submit,
+        KeyCode::BackTab | KeyCode::Up => {
+            form.focus = 0;
+            LoginAction::None
+        }
+        KeyCode::Enter => {
+            if form.focus == 0 && !form.username.is_empty() && form.password.is_empty() {
+                form.focus = 1;
+                LoginAction::None
+            } else {
+                LoginAction::Submit
+            }
+        }
         KeyCode::Backspace => {
             let field = if form.focus == 0 {
                 &mut form.username
@@ -887,6 +903,7 @@ fn login_input(form: &mut LoginForm, key: KeyEvent) -> LoginAction {
         _ => LoginAction::None,
     }
 }
+
 
 /// 密码遮蔽：每个字符显示为 `*`。
 fn mask_password(password: &str) -> String {
@@ -2740,7 +2757,12 @@ mod tests {
 
     #[test]
     fn login_input_enter_submits_esc_cancels() {
-        let mut form = LoginForm::default();
+        let mut form = LoginForm {
+            username: "alice".into(),
+            password: "secret".into(),
+            focus: 1,
+            ..Default::default()
+        };
         assert_eq!(
             login_input(&mut form, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
             LoginAction::Submit
@@ -2750,6 +2772,45 @@ mod tests {
             LoginAction::Cancel
         );
     }
+
+    #[test]
+    fn login_input_enter_moves_to_password_when_empty() {
+        let mut form = LoginForm {
+            username: "alice".into(),
+            password: "".into(),
+            focus: 0,
+            ..Default::default()
+        };
+        assert_eq!(
+            login_input(&mut form, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            LoginAction::None
+        );
+        assert_eq!(form.focus, 1, "回车后应切换到密码输入框");
+    }
+
+    #[test]
+    fn perform_upload_auth_failure_clears_stale_token() {
+        let (port, handle) = mock_server(&[(
+            "/Api/Rank/uploadResult",
+            r#"{"error":1,"msg":"用户名不能为空！"}"#,
+        )]);
+        let store = temp_token_store();
+        store.save("stale-tok").unwrap();
+        let mut app = App::new_with(
+            online_text("你好"),
+            store.clone(),
+            ApiClient::with_base_url_and_store(&format!("http://127.0.0.1:{port}"), Some(store.clone())),
+            temp_settings_store(),
+        );
+        let stats = app.session.finish(Duration::from_secs(10));
+        let up = app.perform_upload(&stats, Duration::from_secs(10));
+        handle.join().unwrap();
+        assert!(matches!(up, UploadState::Failed { need_relogin: true, .. }));
+        assert!(!app.api.is_logged_in(), "客户端会话应被清理");
+        assert!(store.load().is_none(), "磁盘 token 应被清空");
+    }
+
+
 
     #[test]
     fn mask_password_hides_every_char() {

--- a/dazitui/src/main.rs
+++ b/dazitui/src/main.rs
@@ -5,12 +5,11 @@ use std::time::{Duration, Instant};
 
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 use dazitui_core::{
-    ApiClient, ApiError, BUILTIN_SETS, CharStatus, CompetitionType, FONT_SIZE_PT,
+    ApiClient, ApiError, AuthSession, BUILTIN_SETS, CharStatus, CompetitionType, FONT_SIZE_PT,
     LoadError, LoadOptions, Rgb, Session, Settings, SettingsStore, Stats, Text, TextSource,
-    Theme, TokenStore, build_upload_payload, env_credentials, format_share_text,
-    is_auth_failure, load_builtin_text, load_builtin_text_shuffled,
+    Theme, TokenStore, env_credentials, is_auth_failure, load_builtin_text, load_builtin_text_shuffled,
     load_text_from_file, load_text_from_file_with_options,
-    osc_font_size_sequence, osc52_clipboard, should_auto_relogin, to_upload_stats,
+    osc_font_size_sequence, osc52_clipboard,
 };
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
@@ -154,27 +153,18 @@ impl App {
             Session::new_gated_with_words(&text.content, text.source.is_builtin(), &wb)
         };
         let settings = settings_store.load();
-        // token 持久化仅用于请求携带；登录会话（session cookie）不持久化，
-        // 故每次启动都需重新登录（方案 1）。即使加载到持久化 token 也不视为已登录。
-        let saved_token = token_store.load();
-        let (token, logged_in, login_notice) =
-            if let Some((user, pass)) = env_credentials(|k| std::env::var(k).ok()) {
+        // 自动登录与会话恢复：若已有已持久化的会话则直接保持已登录；未登录时若有环境变量则尝试自动登录。
+        let login_notice =
+            if !api.is_logged_in() && let Some((user, pass)) = env_credentials(|k| std::env::var(k).ok()) {
                 match api.login(&user, &pass) {
-                    Ok(r) => {
-                        let _ = token_store.save(&r.token);
-                        (Some(r.token), true, Some("已通过环境变量登录".to_string()))
-                    }
-                    Err(e) => {
-                        (
-                        saved_token,
-                        false,
-                        Some(format!("自动登录失败: {}", api_error_text(&e))),
-                        )
-                    }
+                    Ok(_) => Some("已通过环境变量登录".to_string()),
+                    Err(e) => Some(format!("自动登录失败: {}", api_error_text(&e))),
                 }
             } else {
-                (saved_token, false, None)
+                None
             };
+        let logged_in = api.is_logged_in();
+        let token = api.current_token();
         Self {
             text,
             session,
@@ -402,17 +392,17 @@ impl App {
     /// 不做 token 有效性预探测：getBaseInfo 的 isLogin 恒为 0、无法反映登录态，
     /// token 有效性唯一由上传接口（uploadResult）真实校验，失败走「登录已失效」提示。
     fn download_online(&mut self, competition_type: CompetitionType) {
-        if !self.logged_in {
+        if !self.logged_in && !self.api.is_logged_in() {
             self.online_loading = None;
             self.online_error = Some("请先登录 52dazi（Ctrl-O）".to_string());
             return;
         }
-        let Some(token) = self.token.clone() else {
-            self.online_loading = None;
-            self.online_error = Some("请先登录 52dazi（Ctrl-O）".to_string());
-            return;
-        };
-        match self.api.get_content(&token, competition_type) {
+        if !self.api.is_logged_in() {
+            if let Some(token) = &self.token {
+                self.api.set_session(Some(AuthSession::from_token(token)));
+            }
+        }
+        match self.api.get_content(competition_type) {
             Ok(comp) => {
                 self.text = Text {
                     title: comp.title,
@@ -438,24 +428,8 @@ impl App {
     }
 
     /// 上传成绩并更新成绩视图状态（在线赛文完成跟打后调用）。
-    ///
-    /// 若上传失败因登录失效且配置了 `DAZITUI_USER`/`DAZITUI_PASS`，自动重新登录
-    /// 并重试上传一次；重试仍失败按原失败路径提示。
     fn do_upload(&mut self, stats: &Stats, elapsed: Duration) {
-        let mut upload = self.perform_upload(stats, elapsed);
-        let need_relogin = matches!(
-            &upload,
-            UploadState::Failed {
-                need_relogin: true,
-                ..
-            }
-        );
-        let credentials = env_credentials(|k| std::env::var(k).ok());
-        if should_auto_relogin(need_relogin, credentials.is_some())
-            && let Some((user, pass)) = credentials
-        {
-            upload = self.retry_after_relogin((user, pass), stats, elapsed);
-        }
+        let upload = self.perform_upload(stats, elapsed);
         self.state = AppState::Finished {
             stats: stats.clone(),
             upload,
@@ -485,33 +459,26 @@ impl App {
         }
     }
 
-    /// 执行上传：构造 payload → 调网关 → 处理结果（成功则写剪贴板）。纯状态产出，不修改自身。
+    /// 执行上传：调用 API 客户端一站式上传成绩（包含指标计算、payload 构建、网关通信、自动重登与分享文本生成）。
     fn perform_upload(&self, stats: &Stats, elapsed: Duration) -> UploadState {
-        if !self.logged_in {
+        if !self.logged_in && !self.api.is_logged_in() {
             return UploadState::Failed {
                 message: "未登录，无法上传成绩".to_string(),
                 need_relogin: true,
                 detail: None,
             };
         }
-        let Some(token) = self.token.clone() else {
-            return UploadState::Failed {
-                message: "未登录，无法上传成绩".to_string(),
-                need_relogin: true,
-                detail: None,
-            };
-        };
-        let upload = to_upload_stats(stats, elapsed);
-        let payload = build_upload_payload(&self.text, stats, &upload, elapsed);
-        match self.api.upload_result(&token, &payload) {
-            Ok(rank) => {
-                let ranking = rank.ranking.clone();
-                let rank_num = ranking.as_deref().and_then(|s| s.parse::<u32>().ok());
-                let share_text = format_share_text(&self.text.source, rank_num, &upload);
-                write_clipboard(&share_text);
+        if !self.api.is_logged_in() {
+            if let Some(token) = &self.token {
+                self.api.set_session(Some(AuthSession::from_token(token)));
+            }
+        }
+        match self.api.upload_session(&self.text, stats, elapsed) {
+            Ok(outcome) => {
+                write_clipboard(&outcome.share_text);
                 UploadState::Success {
-                    ranking,
-                    share_text,
+                    ranking: outcome.ranking,
+                    share_text: outcome.share_text,
                 }
             }
             Err(e) => {
@@ -534,6 +501,7 @@ impl App {
         }
     }
 }
+
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -1734,10 +1702,11 @@ mod tests {
 
     /// 测试用 App：临时 token/设置存储 + 不可达 API（无 token 文件时不发网络请求）。
     fn test_app(text: Text) -> App {
+        let store = temp_token_store();
         App::new_with(
             text,
-            temp_token_store(),
-            ApiClient::with_base_url("http://127.0.0.1:1"),
+            store.clone(),
+            ApiClient::with_base_url_and_store("http://127.0.0.1:1", Some(store)),
             temp_settings_store(),
         )
     }
@@ -3082,18 +3051,18 @@ mod tests {
     }
 
     #[test]
-    fn startup_with_saved_token_keeps_token_but_requires_relogin() {
-        // 持久化 token 仍被加载（用于请求携带），但会话不持久化——不视为已登录，需重新登录。
+    fn startup_with_saved_token_keeps_login() {
+        // 本地有已保存 session/token → 直接保持登录，满足 US4（免重复登录）。
         let store = temp_token_store();
         store.save("saved-token").unwrap();
         let app = App::new_with(
             file_text("你好"),
-            store,
-            ApiClient::with_base_url("http://127.0.0.1:1"), // 不发网络请求
+            store.clone(),
+            ApiClient::with_base_url_and_store("http://127.0.0.1:1", Some(store)), // 不发网络请求
             temp_settings_store(),
         );
         assert_eq!(app.token.as_deref(), Some("saved-token"));
-        assert!(!app.logged_in);
+        assert!(app.logged_in);
         assert!(app.login_notice.is_none());
     }
 
@@ -3108,8 +3077,8 @@ mod tests {
         )]);
         let mut app = App::new_with(
             online_text("旧赛文"),
-            store,
-            ApiClient::with_base_url(&format!("http://127.0.0.1:{port}")),
+            store.clone(),
+            ApiClient::with_base_url_and_store(&format!("http://127.0.0.1:{port}"), Some(store)),
             temp_settings_store(),
         );
         app.logged_in = true;
@@ -3131,8 +3100,8 @@ mod tests {
         store.save("tok").unwrap();
         let mut app = App::new_with(
             online_text("你好世界"),
-            store,
-            ApiClient::with_base_url("http://127.0.0.1:1"),
+            store.clone(),
+            ApiClient::with_base_url_and_store("http://127.0.0.1:1", Some(store)),
             temp_settings_store(),
         );
         app.logged_in = true;

--- a/dazitui/src/main.rs
+++ b/dazitui/src/main.rs
@@ -22,8 +22,12 @@ use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
 enum AppState {
     /// 跟打中。
     Typing,
-    /// 已出成绩（成绩视图），携带成绩与上传状态。
-    Finished { stats: Stats, upload: UploadState },
+    /// 已出成绩（成绩视图），携带成绩、上传状态与用时。
+    Finished {
+        stats: Stats,
+        upload: UploadState,
+        elapsed: Duration,
+    },
     /// 载文浏览：功能栏显示文件列表，可预览与载入。
     Browsing,
     /// 内置赛文浏览：功能栏显示套题列表，可载入。
@@ -31,6 +35,7 @@ enum AppState {
     /// 设置视图：切换主题等外观设置。
     Settings,
 }
+
 
 /// 设置视图焦点项下标。
 const FOCUS_THEME: usize = 0;
@@ -256,6 +261,11 @@ impl App {
                 self.logged_in = true;
                 self.login_form = None;
                 self.login_notice = Some("登录成功".to_string());
+                if let AppState::Finished { stats, elapsed, .. } = &self.state {
+                    let stats = stats.clone();
+                    let elapsed = *elapsed;
+                    self.do_upload(&stats, elapsed);
+                }
             }
             Err(e) => {
                 form.busy = false;
@@ -292,16 +302,19 @@ impl App {
             self.state = AppState::Finished {
                 stats: stats.clone(),
                 upload: UploadState::Uploading,
+                elapsed,
             };
             Some((stats, elapsed))
         } else {
             self.state = AppState::Finished {
                 stats,
                 upload: UploadState::NotApplicable,
+                elapsed,
             };
             None
         }
     }
+
 
     /// 进入载文浏览：扫描当前目录文本文件。
     fn open_browser(&mut self) {
@@ -433,8 +446,10 @@ impl App {
         self.state = AppState::Finished {
             stats: stats.clone(),
             upload,
+            elapsed,
         };
     }
+
 
     /// 用环境变量凭据重新登录并重试上传一次；重登失败时保留失败状态并附原始错误。
     fn retry_after_relogin(
@@ -925,7 +940,7 @@ fn list_text_files(dir: &Path) -> Vec<PathBuf> {
 }
 
 fn ui(frame: &mut Frame, app: &App) {
-    if let AppState::Finished { stats, upload } = &app.state {
+    if let AppState::Finished { stats, upload, .. } = &app.state {
         render_result_view(frame, app, stats, upload);
         return;
     }
@@ -1347,8 +1362,12 @@ fn render_result_view(frame: &mut Frame, app: &App, stats: &Stats, upload: &Uplo
     all.extend(upload_lines(upload, theme));
     all.push(Line::from(""));
     if app.text.is_online() {
-        // 在线赛文不支持重打，只能退出或载入其他赛文。
-        all.push(Line::from(" q 退出 | Ctrl-F 载文").fg(color(theme.muted)));
+        // 在线赛文不支持重打。若登录失效，提示 Ctrl-O 登录重试。
+        if let UploadState::Failed { need_relogin: true, .. } = upload {
+            all.push(Line::from(" Ctrl-O 登录并上传 | q 退出 | Ctrl-F 载文").fg(color(theme.muted)));
+        } else {
+            all.push(Line::from(" q 退出 | Ctrl-F 载文").fg(color(theme.muted)));
+        }
     } else {
         all.push(Line::from(" 按任意键重打 | q 退出").fg(color(theme.muted)));
     }
@@ -1398,12 +1417,13 @@ fn upload_lines(upload: &UploadState, theme: Theme) -> Vec<Line<'static>> {
                 lines.push(Line::from(format!(" 原始错误: {d}")).fg(color(theme.muted)));
             }
             if *need_relogin {
-                lines.push(Line::from(" 请按 Ctrl-O 重新登录").fg(color(theme.warn)));
+                lines.push(Line::from(" 请按 Ctrl-O 重新登录（登录后自动重试上传）").fg(color(theme.warn)));
             }
             lines
         }
     }
 }
+
 
 /// 内置赛文每页显示的单位数（单字赛文每页 10 字，词组赛文每页 10 个词）。
 const BUILTIN_ITEMS_PER_PAGE: usize = dazitui_core::GROUP_SIZE;
@@ -3192,4 +3212,46 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn submit_login_retries_pending_upload_in_finished_state() {
+        let (port, handle) = mock_server(&[
+            (
+                "/Api/User/login",
+                r#"{"error":0,"msg":{"token":"fresh-token"}}"#,
+            ),
+            (
+                "/Api/Rank/uploadResult",
+                r#"{"error":0,"msg":{"ranking":1,"rankTips":"第1名"}}"#,
+            ),
+        ]);
+        let mut app = test_app(online_text("你好世界"));
+        app.api = ApiClient::with_base_url(&format!("http://127.0.0.1:{port}"));
+        let stats = app.session.finish(Duration::from_secs(30));
+        app.state = AppState::Finished {
+            stats: stats.clone(),
+            upload: UploadState::Failed {
+                message: "登录已失效，请重新登录".to_string(),
+                need_relogin: true,
+                detail: Some("用户名不能为空！".to_string()),
+            },
+            elapsed: Duration::from_secs(30),
+        };
+        app.open_login();
+        if let Some(form) = app.login_form.as_mut() {
+            form.username = "alice".to_string();
+            form.password = "secret".to_string();
+        }
+        app.submit_login();
+        handle.join().unwrap();
+        assert_eq!(app.token.as_deref(), Some("fresh-token"));
+        assert!(matches!(
+            &app.state,
+            AppState::Finished {
+                upload: UploadState::Success { ranking, .. },
+                ..
+            } if ranking.as_deref() == Some("1")
+        ));
+    }
 }
+


### PR DESCRIPTION
## 概述

本 PR 彻底修复了 52dazi 在线赛文载入、成绩上传与登录会话管理相关的一系列问题（关联 Issue #7、#24、#25、#26）。

---

## 核心变更

### 1. 协议规范与字段对齐
- **网关根地址**：升级为官方 HTTPS 网关 `https://www.jsxiaoshi.com/index.php`，并在 `dazitui-core` 中为 `ureq` 启用 `rustls` 特性以支持 TLS 通信。
- **公共请求头与载荷**：在 AES 加密公共字段中补充 `from: "web"` 和 Unix 秒级 `timestamp`。
- **赛文解析**：优先解析 `a_name`（真实标题）与 `a_content`（真实内容），兼容数字键兜底。
- **上传载荷**：补齐数值型 `accuracy: f64`、`isFirstSubmit: 1`，修正 `textTitle` 赛文标题字段传递。

### 2. 深模块架构收敛（`upload_session`）
- 在 `ApiClient` 中提供高层聚合接口 `upload_session(&Text, &Stats, Duration)`：一站式完成登录校验、指标计算、Payload 构造、网关通信、环境变量自动重登重试与分享文案生成。
- UI 应用层（`dazitui`）精简，全面接入深模块，彻底消除应用层与 API 客户端之间的会话状态不同步。

### 3. 会话生命周期管理与断点续传
- **断点重试**：在成绩结算视图（`AppState::Finished`）中若因 Token 失效导致上传失败，用户通过 `Ctrl-O` 重新登录后，系统自动重试上传当前已完成的成绩，避免跟打成果丢失。
- **失效 Token 清理**：服务端返回鉴权失败时，立即清理内存会话与磁盘文件 `~/.config/dazitui/token`，避免残留死 Token 造成假登录死循环。
- **登录弹窗交互优化**：支持 `Tab` / `Down` / `Up` / `Shift-Tab` / `Enter` 平滑切换焦点与提交。

---

## 验证情况

- **单元测试与集成测试**：全套 183 个测试全部通过（GREEN）。
- **保证系统（GBC）**：`gbc doctor check` 验证全局意图与依赖图完全一致。
- **真实网络测试**：通过集成测试成功与 52dazi 官方生产网关握手通信。